### PR TITLE
ADD: Bag of Word (tfidf) on URL network locations

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -15,14 +15,22 @@ train, test = get_train_test()
 train =  process_dataframe(train)
 test = process_dataframe(test)
 
-# Continue Bag Of Word Text Vectors
-glovet = GloveTransformer("glove.6B.%sd.txt.gz" % 300)
-train['glove'] = train['text_clean'].apply(lambda x: glovet.txt2avg_vector(x))
-test['glove'] = test['text_clean'].apply(lambda x: glovet.txt2avg_vector(x))
+# tfidf on text_clean
+tfidf = TFIDFTransformer('text_clean')
+train = tfidf.fit_transform(train)
+test = tfidf.transform(test)
+
+# tfidf on network locations
+tfidf = TFIDFTransformer('netlocs')
+train = tfidf.fit_transform(train)
+test = tfidf.transform(test)
 
 # train logistic regression on training data with tf-idf as features and predict on testing data
 train = train.dropna()
-model = gl.logistic_classifier.create(train, target='sponsored', features=['glove'], class_weights='auto')
+model = gl.logistic_classifier.create(
+    train, target='sponsored', features=['tfidf_text_clean', 'tfidf_netlocs'],
+    class_weights='auto'
+)
 
 test = test.dropna()
 model.evaluate(test)

--- a/config.py
+++ b/config.py
@@ -2,3 +2,4 @@
 PATH_TO_JSON = "processed_data"
 PATH_TO_TRAIN_LABELS = "data/train.csv"
 PATH_TO_TEST_LABELS = "data/sampleSubmission.csv"
+GLOVE_FOLDER = "data/"

--- a/data_etl.py
+++ b/data_etl.py
@@ -63,9 +63,17 @@ def process_dataframe(sf):
     sf = create_link_netloc(sf)
     return sf
 
-def create_submission(test, ypred):
+def create_balanced_validation(train, target_name="sponsored", n_positive_examples=1000):
+    """ supports the case whene the target is binary """
+    train = gl.toolkits.cross_validation.shuffle(train)
+    neg_valid = train[(train['sponsored'] == 0)][:1000]
+    pos_valid = train[(train['sponsored'] == 1)][:1000]
+    valid = neg_valid.append(pos_valid)
+    return valid
+
+def create_submission(test, ypred, name="data/submission_version_1.csv"):
     """ create submission.csv """
     submission = gl.SFrame()
     submission['sponsored'] = ypred 
     submission['file'] = test['id'].apply(lambda x: x + '_raw_html.txt')
-    submission.save('submission_version_1.csv', format='csv')
+    submission.save(name, format='csv')

--- a/data_etl.py
+++ b/data_etl.py
@@ -3,6 +3,7 @@
 Extract, Transform, Load data into the proper format
 """
 import re
+from urlparse import urlparse
 import graphlab as gl
 from config import PATH_TO_JSON, PATH_TO_TRAIN_LABELS, PATH_TO_TEST_LABELS
 
@@ -42,10 +43,24 @@ def clean_text(sf):
     sf['text_clean'] = sf['text_clean'].apply(lambda x: x.strip())
     return sf
 
+def create_link_netloc(sf):
+    """ a simple method to extract the net(work) loc(ations) in url links """
+    def get_netloc(link):
+        try:
+            return urlparse(link).netloc
+        except:
+            return ''
+
+    sf["netlocs"] = sf["links"].apply(
+        lambda x: ' '.join([get_netloc(link) for link in x])
+    ) 
+    return sf
+
 def process_dataframe(sf):
     """ a wrapper method around the 2 methods above """
     sf = clean_text(sf)
     sf = create_count_features(sf)
+    sf = create_link_netloc(sf)
     return sf
 
 def create_submission(test, ypred):

--- a/feature_engr.py
+++ b/feature_engr.py
@@ -19,8 +19,8 @@ class TFIDFTransformer(object):
     """ Wrapper around GraphLabs bag of words and TFIDF models to act
     more like a scikit estimator """
 
-    def __init__(self):
-        pass
+    def __init__(self, column_name):
+        self.column_name = column_name
 
     def fit_transform(self, train):
         """ unlike scikit, features and targets are encapsulated in the 
@@ -36,15 +36,15 @@ class TFIDFTransformer(object):
             in column 'tfidf'.
         """
         # create word counts and remove countwords
-        bow_trn = gl.text_analytics.count_words(train['text_clean'])
+        bow_trn = gl.text_analytics.count_words(train[self.column_name])
         bow_trn = bow_trn.dict_trim_by_keys(gl.text_analytics.stopwords())
         
         # add bag of words to sframe
-        train['bow'] = bow_trn
+        train['bow_'+self.column_name] = bow_trn
         
         self.encoder = gl.feature_engineering.create(
               train
-            , TFIDF('bow', output_column_name='tfidf')
+            , TFIDF('bow_'+self.column_name, output_column_name='tfidf_'+self.column_name)
             )
         
         return self.encoder.transform(train)
@@ -61,11 +61,11 @@ class TFIDFTransformer(object):
             in column 'tfidf'.
         """
         # create word counts and remove countwords
-        bow_tst = gl.text_analytics.count_words(test['text_clean'])
+        bow_tst = gl.text_analytics.count_words(test[self.column_name])
         bow_tst = bow_tst.dict_trim_by_keys(gl.text_analytics.stopwords())
 
         # add the bag of words to both sframes
-        test['bow'] = bow_tst
+        test['bow_'+self.column_name] = bow_tst
 
         return self.encoder.transform(test)
 

--- a/logs/bucket0/baseline.log
+++ b/logs/bucket0/baseline.log
@@ -1,0 +1,67 @@
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/processed_data/chunk0.json
+PROGRESS: Parsing completed. Parsed 100 lines in 1.43956 secs.
+------------------------------------------------------
+Inferred types from first line of file as 
+column_type_hints=[dict]
+If parsing fails due to incorrect types, you can correct
+the inferred type list above and pass it to read_csv in
+the column_type_hints argument
+------------------------------------------------------
+PROGRESS: Read 2213 lines. Lines per second: 895.341
+PROGRESS: Read 8911 lines. Lines per second: 1079.48
+PROGRESS: Read 16413 lines. Lines per second: 1167.76
+PROGRESS: Read 23831 lines. Lines per second: 1176.58
+PROGRESS: Read 31080 lines. Lines per second: 1222.06
+PROGRESS: Read 37781 lines. Lines per second: 1206.11
+PROGRESS: Read 45029 lines. Lines per second: 1201.96
+PROGRESS: Read 51894 lines. Lines per second: 1188.88
+PROGRESS: Read 58974 lines. Lines per second: 1191.86
+PROGRESS: Read 65771 lines. Lines per second: 1195.9
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/processed_data/chunk0.json
+PROGRESS: Parsing completed. Parsed 67507 lines in 55.2616 secs.
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/train.csv
+PROGRESS: Parsing completed. Parsed 100 lines in 0.212416 secs.
+------------------------------------------------------
+Inferred types from first line of file as 
+column_type_hints=[str,int]
+If parsing fails due to incorrect types, you can correct
+the inferred type list above and pass it to read_csv in
+the column_type_hints argument
+------------------------------------------------------
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/train.csv
+PROGRESS: Parsing completed. Parsed 101107 lines in 0.11789 secs.
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/sampleSubmission.csv
+PROGRESS: Parsing completed. Parsed 100 lines in 0.487424 secs.
+------------------------------------------------------
+Inferred types from first line of file as 
+column_type_hints=[str,int]
+If parsing fails due to incorrect types, you can correct
+the inferred type list above and pass it to read_csv in
+the column_type_hints argument
+------------------------------------------------------
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/sampleSubmission.csv
+PROGRESS: Parsing completed. Parsed 235917 lines in 0.202576 secs.
+PROGRESS: Creating a validation set from 5 percent of training data. This may take a while.
+          You can set ``validation_set=None`` to disable validation tracking.
+
+PROGRESS: Logistic regression:
+PROGRESS: --------------------------------------------------------
+PROGRESS: Number of examples          : 19173
+PROGRESS: Number of classes           : 2
+PROGRESS: Number of feature columns   : 1
+PROGRESS: Number of unpacked features : 452597
+PROGRESS: Number of coefficients    : 452598
+PROGRESS: Starting L-BFGS
+PROGRESS: --------------------------------------------------------
+PROGRESS: +-----------+----------+-----------+--------------+-------------------+---------------------+
+PROGRESS: | Iteration | Passes   | Step size | Elapsed Time | Training-accuracy | Validation-accuracy |
+PROGRESS: +-----------+----------+-----------+--------------+-------------------+---------------------+
+PROGRESS: | 1         | 3        | 0.000052  | 2.089698     | 0.682835          | 0.535714            |
+PROGRESS: | 2         | 5        | 1.000000  | 3.118383     | 0.980546          | 0.892857            |
+PROGRESS: | 3         | 6        | 1.000000  | 3.649882     | 0.983518          | 0.894737            |
+PROGRESS: | 4         | 7        | 1.000000  | 4.243944     | 0.986909          | 0.896617            |
+PROGRESS: | 5         | 8        | 1.000000  | 4.922802     | 0.986909          | 0.900376            |
+PROGRESS: | 6         | 9        | 1.000000  | 5.600038     | 0.988056          | 0.904135            |
+PROGRESS: | 10        | 13       | 1.000000  | 8.231323     | 0.988056          | 0.897556            |
+PROGRESS: +-----------+----------+-----------+--------------+-------------------+---------------------+
+[INFO] Stopping the server connection.

--- a/logs/bucket0/gloveavg.log
+++ b/logs/bucket0/gloveavg.log
@@ -1,0 +1,61 @@
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/processed_data/chunk0.json
+PROGRESS: Parsing completed. Parsed 100 lines in 1.03065 secs.
+------------------------------------------------------
+Inferred types from first line of file as 
+column_type_hints=[dict]
+If parsing fails due to incorrect types, you can correct
+the inferred type list above and pass it to read_csv in
+the column_type_hints argument
+------------------------------------------------------
+PROGRESS: Read 2213 lines. Lines per second: 1777.66
+PROGRESS: Read 12607 lines. Lines per second: 1982.72
+PROGRESS: Read 23831 lines. Lines per second: 2060.58
+PROGRESS: Read 34439 lines. Lines per second: 2047.93
+PROGRESS: Read 45029 lines. Lines per second: 1908.31
+PROGRESS: Read 53684 lines. Lines per second: 1872.66
+PROGRESS: Read 64077 lines. Lines per second: 1904.69
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/processed_data/chunk0.json
+PROGRESS: Parsing completed. Parsed 67507 lines in 34.6393 secs.
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/train.csv
+PROGRESS: Parsing completed. Parsed 100 lines in 0.099435 secs.
+------------------------------------------------------
+Inferred types from first line of file as 
+column_type_hints=[str,int]
+If parsing fails due to incorrect types, you can correct
+the inferred type list above and pass it to read_csv in
+the column_type_hints argument
+------------------------------------------------------
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/train.csv
+PROGRESS: Parsing completed. Parsed 101107 lines in 0.073462 secs.
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/sampleSubmission.csv
+PROGRESS: Parsing completed. Parsed 100 lines in 0.230667 secs.
+------------------------------------------------------
+Inferred types from first line of file as 
+column_type_hints=[str,int]
+If parsing fails due to incorrect types, you can correct
+the inferred type list above and pass it to read_csv in
+the column_type_hints argument
+------------------------------------------------------
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/sampleSubmission.csv
+PROGRESS: Parsing completed. Parsed 235917 lines in 0.118507 secs.
+PROGRESS: Creating a validation set from 5 percent of training data. This may take a while.
+          You can set ``validation_set=None`` to disable validation tracking.
+
+PROGRESS: Logistic regression:
+PROGRESS: --------------------------------------------------------
+PROGRESS: Number of examples          : 19232
+PROGRESS: Number of classes           : 2
+PROGRESS: Number of feature columns   : 1
+PROGRESS: Number of unpacked features : 300
+PROGRESS: Number of coefficients    : 301
+PROGRESS: Starting Newton Method
+PROGRESS: --------------------------------------------------------
+PROGRESS: +-----------+----------+--------------+-------------------+---------------------+
+PROGRESS: | Iteration | Passes   | Elapsed Time | Training-accuracy | Validation-accuracy |
+PROGRESS: +-----------+----------+--------------+-------------------+---------------------+
+PROGRESS: | 1         | 2        | 12.303720    | 0.663582          | 0.664677            |
+PROGRESS: | 2         | 3        | 18.109800    | 0.681988          | 0.686567            |
+PROGRESS: | 3         | 4        | 23.845002    | 0.687240          | 0.690547            |
+PROGRESS: | 4         | 5        | 29.781446    | 0.688280          | 0.692537            |
+PROGRESS: | 5         | 6        | 35.480370    | 0.688072          | 0.692537            |
+PROGRESS: +-----------+----------+--------------+-------------------+---------------------+

--- a/logs/bucket0/tfidf_unigram_text+tfidf_unigram_netloc.log
+++ b/logs/bucket0/tfidf_unigram_text+tfidf_unigram_netloc.log
@@ -1,0 +1,66 @@
+[INFO] Start server at: ipc:///tmp/graphlab_server-17036 - Server binary: /home/rlouie/anaconda/envs/dato-env/lib/python2.7/site-packages/graphlab/unity_server - Server log: /tmp/graphlab_server_1439369664.log
+[INFO] GraphLab Server Version: 1.5.2
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/processed_data/chunk0.json
+PROGRESS: Parsing completed. Parsed 100 lines in 0.401407 secs.
+------------------------------------------------------
+Inferred types from first line of file as 
+column_type_hints=[dict]
+If parsing fails due to incorrect types, you can correct
+the inferred type list above and pass it to read_csv in
+the column_type_hints argument
+------------------------------------------------------
+PROGRESS: Read 2213 lines. Lines per second: 1708.11
+PROGRESS: Read 14375 lines. Lines per second: 2025.09
+PROGRESS: Read 25831 lines. Lines per second: 2119.22
+PROGRESS: Read 36143 lines. Lines per second: 2099.92
+PROGRESS: Read 48294 lines. Lines per second: 2119.7
+PROGRESS: Read 62739 lines. Lines per second: 2257.99
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/processed_data/chunk0.json
+PROGRESS: Parsing completed. Parsed 67507 lines in 28.757 secs.
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/train.csv
+PROGRESS: Parsing completed. Parsed 100 lines in 0.11499 secs.
+------------------------------------------------------
+Inferred types from first line of file as 
+column_type_hints=[str,int]
+If parsing fails due to incorrect types, you can correct
+the inferred type list above and pass it to read_csv in
+the column_type_hints argument
+------------------------------------------------------
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/train.csv
+PROGRESS: Parsing completed. Parsed 101107 lines in 0.077832 secs.
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/sampleSubmission.csv
+PROGRESS: Parsing completed. Parsed 100 lines in 0.185855 secs.
+------------------------------------------------------
+Inferred types from first line of file as 
+column_type_hints=[str,int]
+If parsing fails due to incorrect types, you can correct
+the inferred type list above and pass it to read_csv in
+the column_type_hints argument
+------------------------------------------------------
+PROGRESS: Finished parsing file /home/rlouie/repos/dato-native/data/sampleSubmission.csv
+PROGRESS: Parsing completed. Parsed 235917 lines in 0.120956 secs.
+PROGRESS: Creating a validation set from 5 percent of training data. This may take a while.
+          You can set ``validation_set=None`` to disable validation tracking.
+
+PROGRESS: Logistic regression:
+PROGRESS: --------------------------------------------------------
+PROGRESS: Number of examples          : 19233
+PROGRESS: Number of classes           : 2
+PROGRESS: Number of feature columns   : 2
+PROGRESS: Number of unpacked features : 534422
+PROGRESS: Number of coefficients    : 534423
+PROGRESS: Starting L-BFGS
+PROGRESS: --------------------------------------------------------
+PROGRESS: +-----------+----------+-----------+--------------+-------------------+---------------------+
+PROGRESS: | Iteration | Passes   | Step size | Elapsed Time | Training-accuracy | Validation-accuracy |
+PROGRESS: +-----------+----------+-----------+--------------+-------------------+---------------------+
+PROGRESS: | 1         | 3        | 0.000052  | 1.835729     | 0.810326          | 0.623506            |
+PROGRESS: | 2         | 5        | 1.000000  | 2.587049     | 0.987209          | 0.911355            |
+PROGRESS: | 3         | 6        | 1.000000  | 3.073601     | 0.989601          | 0.921315            |
+PROGRESS: | 4         | 7        | 1.000000  | 3.571943     | 0.991369          | 0.926295            |
+PROGRESS: | 5         | 8        | 1.000000  | 4.069394     | 0.992097          | 0.926295            |
+PROGRESS: | 6         | 9        | 1.000000  | 4.579527     | 0.991993          | 0.928287            |
+PROGRESS: | 10        | 13       | 1.000000  | 6.582834     | 0.992357          | 0.926295            |
+PROGRESS: +-----------+----------+-----------+--------------+-------------------+---------------------+
+[INFO] Stopping the server connection.
+


### PR DESCRIPTION
This commit incorporates both my experiment with 
- continuous valued word vectors (king - man + woman = queen)
- bag of words (enhanced by tf-idf) on the URL link network locations

While Average Glove Vectors did not perform well as an experiment, it represents a good first attempt at writing extensible code for data transformation and feature engineering!

The important bit is that my experiment adding BOW-TFIDF on URL Network Locations features yielded a **90% -> 92.5% improvement on the validation set of the Bucket0 Data**. This makes good cause for us to run the whole dataset with this model, and possibly make a submission.  See the complete log in `logs/bucket0/tfidf_unigram_text+tfidf_unigram_netloc.log` 
